### PR TITLE
Fixed ClassNotFoundException due to typo

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/extension/mockito/MockitoArchiveAppender.java
+++ b/impl/src/main/java/org/jboss/arquillian/extension/mockito/MockitoArchiveAppender.java
@@ -14,7 +14,7 @@ public class MockitoArchiveAppender extends CachedAuxilliaryArchiveAppender {
 		 JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "arquillian-mockito.jar")
                  .addPackages(
                        true, 
-                       "org.mokito", 
+                       "org.mockito", 
                        "org.objenesis",
                        CDIExtension.class.getPackage().getName()
                       )


### PR DESCRIPTION
The added package should read org.mockito instead of org.mokito. 
